### PR TITLE
Add support for section length arithmetic using + sign as used in stm32f7xx-hal crate.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,7 @@ fn find_ram_in_linker_script(linker_script: &str) -> Option<MemoryEntry> {
             let boundary_pos = segment
                 .find(|c| c == 'K' || c == 'M')
                 .unwrap_or(segment.len());
-            let mut length: u32 = tryc!(segment[..boundary_pos].parse().ok());
+            let length: u32 = tryc!(segment[..boundary_pos].parse().ok());
             let raw = &segment[boundary_pos..];
             let mut chars = raw.chars();
             let unit = chars.next();


### PR DESCRIPTION
This change adds support for defining the RAM region's length as `10K + 10M`. This type of notation is used in the stm32f7xx-hal crate and flip-link failed with the message `MEMORY.RAM found after scanning linker scripts` which was also fixed to add the missing `not`.