### PR TITLE
Problem with memory.x in the project root

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,10 @@ fn notmain() -> Result<i32, anyhow::Error> {
 
     // invoke the linker a second time
     let mut args = args;
+    // add the current dir to the linker search path to include all unmodified scripts there
+    // HACK `-L` needs to go after `-flavor gnu`; position is currently hardcoded
+    args.insert(2, "-L".to_string());
+    args.insert(3, current_dir.to_str().unwrap_or(".").to_string());
     // we need to override `_stack_start` to make the stack start below fake RAM
     args.push(format!("--defsym=_stack_start={}", new_origin));
 


### PR DESCRIPTION
When the linker script with RAM location is in the root directory where you invoke `cargo` it is always used by the linker.
So only the beginning of the stack is changed which leads to an invalid memory layout.

When you look at the man page for GNU `ld` it says for the `-T` option:
> If scriptfile does not exist in the current directory, "ld" looks for it in the directories specified by any preceding -L options.

So it seems that this is also valid for included scripts.

As a first attempt to fix this problem I set the working dir for the second linker invocation to the temp dir containing the modified script. This works for my setup where I have a `memory.x` in the project root as well as for the example app in this repository.

It could be a problem though when you have multiple linker scripts in project root. But maybe you could set the project root as additional `-L` directory. What do you think?