### PR TITLE
Verify initial stack-pointer to be inside `static RAM`

### DIFF
--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,4 +1,11 @@
+use std::fs;
+
+/// Path to test app
 const CRATE: &str = "test-flip-link-app";
+/// Example firmware in `$CRATE/examples`
+const FILES: [&str; 4] = ["crash", "exception", "hello", "panic"];
+/// Compilation target firmware is build for
+const TARGET: &str = "thumbv7m-none-eabi";
 
 #[test]
 fn should_link_example_firmware() -> anyhow::Result<()> {
@@ -10,6 +17,30 @@ fn should_link_example_firmware() -> anyhow::Result<()> {
 
     // Assert
     cmd.success();
+
+    // ---
+    Ok(())
+}
+
+#[test]
+fn should_verify_memory_layout() -> anyhow::Result<()> {
+    // Arrange
+    cargo::check_flip_link();
+
+    // Act
+    cargo::build_example_firmware(CRATE).success();
+
+    // Assert
+    for elf_path in elf::paths() {
+        // read and parse elf-file
+        let elf = fs::read(elf_path)?;
+        let object = object::File::parse(&*elf)?;
+
+        // get the relevant sections
+        let (bss, data, uninit, vector_table) = elf::get_sections(&object)?;
+        // compute the initial stack-pointer from `.vector_table`
+        let initial_sp = elf::compute_initial_sp(&vector_table)?;
+    }
 
     // ---
     Ok(())
@@ -41,5 +72,60 @@ mod cargo {
             .unwrap()
             .assert()
             .success();
+    }
+}
+
+mod elf {
+    use std::convert::TryInto;
+
+    use anyhow::anyhow;
+    use object::{File, Object, ObjectSection, Section};
+
+    use super::{CRATE, FILES, TARGET};
+
+    /// Get the initial stack pointer.
+    ///
+    /// It is the first 32-bit word in the `.vector_table` section,
+    /// according to the "ARMv6-M Architecture Reference Manual".
+    pub fn compute_initial_sp(vector_table: &Section) -> anyhow::Result<u64> {
+        let data = vector_table.uncompressed_data()?;
+        let sp = u32::from_le_bytes(data[..4].try_into()?);
+        Ok(sp as u64)
+    }
+
+    /// Get the following sections from the elf-file:
+    /// * `.bss`
+    /// * `.data`
+    /// * `.uninit`
+    /// * `.vector_table`
+    pub fn get_sections<'data, 'file>(
+        object: &'file File<'data>,
+    ) -> anyhow::Result<(
+        Section<'data, 'file>,
+        Section<'data, 'file>,
+        Section<'data, 'file>,
+        Section<'data, 'file>,
+    )> {
+        // try to get section, else error
+        let get_section = |section_name| {
+            object
+                .section_by_name(section_name)
+                .ok_or(anyhow!("error getting section `{}`", section_name))
+        };
+
+        Ok((
+            get_section(".bss")?,
+            get_section(".data")?,
+            get_section(".uninit")?,
+            get_section(".vector_table")?,
+        ))
+    }
+
+    /// Paths to firmware binaries.
+    pub fn paths() -> Vec<String> {
+        FILES
+            .iter()
+            .map(|file_name| format!("{}/target/{}/debug/examples/{}", CRATE, TARGET, file_name))
+            .collect()
     }
 }


### PR DESCRIPTION
This PR verifies that the `initial stack-pointer` of each of the four example apps is inside the `static RAM` region, after being linked with `flip-link`.

I've made the choice to have one test for all example apps, instead of one test for each test. This approach is a bit easier to implement, but has the drawback of less error-resolution. E.g. if one of the examples would fail to compile the tests fail completely, instead of running the other ones successfully.

Depends on #40  and fixes #25.