### PR TITLE
Avoid the `tempfile` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,12 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
 name = "bstr"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,10 +67,10 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "env_logger",
+ "getrandom",
  "log",
  "object",
  "rstest",
- "tempfile",
 ]
 
 [[package]]
@@ -136,12 +130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
 name = "predicates"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,68 +174,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rstest"
@@ -301,20 +231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
-dependencies = [
- "cfg-if",
- "libc",
- "rand",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
 name = "treeline"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,28 +262,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xtest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 env_logger = { version = "0.8", default-features = false }
 log = "0.4"
 object = { version = "0.25", default-features = false, features = ["read_core", "elf", "std"] }
-getrandom = "0.2.3"
+getrandom = "0.2"
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 env_logger = { version = "0.8", default-features = false }
 log = "0.4"
 object = { version = "0.25", default-features = false, features = ["read_core", "elf", "std"] }
-tempfile = "3.2"
+getrandom = "0.2.3"
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/src/linking.rs
+++ b/src/linking.rs
@@ -4,8 +4,6 @@ use std::{
     process::{Command, ExitStatus},
 };
 
-use tempfile::TempDir;
-
 const LINKER: &str = "rust-lld";
 
 /// Normal linking with just the arguments the user provides
@@ -38,7 +36,7 @@ pub fn link_normally(args: &[String]) -> io::Result<ExitStatus> {
 pub fn link_modified(
     args: &[String],
     current_dir: &Path,
-    custom_linker_script_location: &TempDir,
+    custom_linker_script_dir: &Path,
     stack_start: u64,
 ) -> io::Result<ExitStatus> {
     let mut c = Command::new(LINKER);
@@ -54,7 +52,7 @@ pub fn link_modified(
         .arg(format!("--defsym=_stack_start={}", stack_start))
         // set working directory to temporary directory containing our new linker script
         // this makes sure that it takes precedence over the original one
-        .current_dir(custom_linker_script_location.path());
+        .current_dir(custom_linker_script_dir);
     log::trace!("{:?}", c);
 
     c.status()

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn notmain() -> anyhow::Result<i32> {
     Ok(0)
 }
 
-fn in_tempdir<T>(cb: impl FnOnce(&Path) -> anyhow::Result<T>) -> anyhow::Result<T> {
+fn in_tempdir<T>(callback: impl FnOnce(&Path) -> anyhow::Result<T>) -> anyhow::Result<T> {
     // We avoid the `tempfile` crate because it pulls in quite a few dependencies.
 
     let mut random = [0; 8];
@@ -120,7 +120,7 @@ fn in_tempdir<T>(cb: impl FnOnce(&Path) -> anyhow::Result<T>) -> anyhow::Result<
     path.push(format!("flip-link-{:02x?}", random));
     fs::create_dir(&path)?;
 
-    let res = cb(&path);
+    let res = callback(&path);
 
     // Just in case https://github.com/rust-lang/rust/issues/29497 hits us, we ignore the error from
     // removing the directory and just let it linger until the machine reboots ¯\_(ツ)_/¯.


### PR DESCRIPTION
`tempfile` pulls in an amazing number of dependencies, which we don't really need just for storing a single linker script.

Note that I wasn't able to properly test this because the flip-link testsuite doesn't seem to work.