### PR TITLE
`xtest`: Pass `--force` to `cargo install`

### DIFF
--- a/xtest/src/main.rs
+++ b/xtest/src/main.rs
@@ -17,7 +17,7 @@ mod cargo {
     /// Install local revision of `flip-link`.
     pub fn install_flip_link() -> anyhow::Result<()> {
         let status = Command::new("cargo")
-            .args(&["install", "--debug", "--path", "."])
+            .args(&["install", "--debug", "--force", "--path", "."])
             .status()?;
         match status.success() {
             false => Err(anyhow!("installing flip-link from path")),


### PR DESCRIPTION
This makes sure that flip-link gets reinstalled, even if it is already
present on the system.