### PR TITLE
search linker scripts in cwd first

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,9 @@ const EXIT_CODE_FAILURE: i32 = 1;
 const SP_ALIGN: u64 = 8;
 
 fn main() -> Result<()> {
+    // clippy complains about redundant closure, but in fact
+    // the function signature isn't 100% compatible so we must wrap it
+    #[allow(clippy::redundant_closure)]
     notmain().map(|code| process::exit(code))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,8 +208,8 @@ impl LinkerScript {
 }
 
 fn get_linker_scripts(args: &[String], current_dir: &Path) -> Result<Vec<LinkerScript>> {
-    let mut search_paths = argument_parser::get_search_paths(args);
-    search_paths.push(current_dir.into());
+    let mut search_paths = vec![current_dir.into()];
+    search_paths.extend(argument_parser::get_search_paths(args));
 
     let mut search_targets = argument_parser::get_search_targets(args);
 


### PR DESCRIPTION
harmonize linker script directory search order with non-`flip-link` linkers to reduce surprises.
Specifically, other crates might introduce spurious and potentially wrong `memory.x` scripts, this PR attempts to do some damage control by searching the current working directory first