### PR TITLE
ci: cache cargo registry & build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           target: ${{ env.CORE_TARGET }}
-      # make rustc version to cache key
-      - id: rustc
+      - name: make rustc version available to cache keys
+        id: rustc
         run: echo "::set-output name=version::$(rustc -V)"
-      # cache Cargo registry
-      - uses: actions/cache@v2
+      - name: cache Cargo registry
+        uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry/cache
@@ -45,8 +45,8 @@ jobs:
           key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-registry-
-      # cache Cargo build artifacts
-      - uses: actions/cache@v2
+      - name: cache Cargo build artifacts
+        uses: actions/cache@v2
         with:
           path: target
           key: cargo-target-${{ runner.os }}-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,25 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           target: ${{ env.CORE_TARGET }}
+      # make rustc version to cache key
+      - id: rustc
+        run: echo "::set-output name=version::$(rustc -V)"
+      # cache Cargo registry
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/index
+          key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-
+      # cache Cargo build artifacts
+      - uses: actions/cache@v2
+        with:
+          path: target
+          key: cargo-target-${{ runner.os }}-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-target-${{ runner.os }}-${{ steps.rustc.outputs.version }}-
       - name: Run testsuite
         run: cargo xtest
 


### PR DESCRIPTION
time savings on cache hit

| Job             | before | after | after/before |
|-----------------|--------|-------|--------------|
| ubuntu-stable   | 105s   | 37s   |          35% |
| macos-stable    | 132s   | 68s   |          51% |
| windows-stable  | 176s   | 98s   |          55% |
| ubuntu-nightly  | 92s    | 40s   |          43% |
| macos-nightly   | 127s   | 65s   |          51% |
| windows-nightly | 163s   | 103s  |          63% |

don't ask me how to replicate the caching steps into the non-matrix job without copy-pasting the whole thing because I don't know :P
