### PR TITLE
Goodbye bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,2 +1,0 @@
-delete_merged_branches = true
-status = ["ci"]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,7 @@ on:
     # opened, reopened, synchronize are the default types for pull_request.
     # labeled, unlabeled ensure this check is also run if a label is added or removed.
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
 
 name: Changelog
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: CI
 
 on:
-  push:
-    branches: [main, staging, trying]
   pull_request:
     branches: [main]
   schedule:
     # runs 1 min after 2 or 1 AM (summer/winter) berlin time
     - cron: "1 0 * * *"
+  merge_group:
+
 env:
   CARGO_TERM_COLOR: always
   CORE_TARGET: thumbv7m-none-eabi # needed by `core`
@@ -72,16 +72,3 @@ jobs:
       - run: cargo clippy -- --deny warnings
       - run: cargo clippy -- --deny warnings
         working-directory: test-flip-link-app/
-
-  # Refs: https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
-  # bors.tech integration
-  ci-success:
-    name: ci
-    if: success()
-    needs:
-      - static-checks
-      - test
-    runs-on: ubuntu-latest
-    steps:
-      - name: CI succeeded
-        run: exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#xx]: CI: Switch from bors to github merge queue
 - [#75]: End of year refactoring
 - [#74]: CI: Simplify
 - [#72]: CI: Install Rust manually
-- [#71]: Add changelog enforcer
+- [#71]: CI: Add changelog enforcer
 - [#70]: Support addition in ORIGIN
 
+[#xx]: https://github.com/knurling-rs/flip-link/pull/xx
 [#75]: https://github.com/knurling-rs/flip-link/pull/75
 [#74]: https://github.com/knurling-rs/flip-link/pull/74
 [#72]: https://github.com/knurling-rs/flip-link/pull/72


### PR DESCRIPTION
The publicly hosted instance of bors-ng is deprecated. Therefore we switch to GitHub merge queue.

Two things are happening:

- This PR edits config files to switch from bors to the new github merge queue.
- Additionally the repository settings and in particular the branch protection rules are edited as described in [the docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

I am a bit unsure how to test this without creating a huge amount of pull requests, but I hope the changed settings already take effect for this PR.