### PR TITLE
Ignore comments in linker script (fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#84]: Fix for comments in linker script
+
+[#84]: https://github.com/knurling-rs/flip-link/pull/84
+
 ## [v0.1.7] - 2023-07-20
 
 - [#79]: Summer cleanup

--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -10,7 +10,8 @@ pub fn get_output_path(args: &[String]) -> crate::Result<&String> {
 /// Get `search_paths`, specified by `-L`
 pub fn get_search_paths(args: &[String]) -> Vec<PathBuf> {
     args.windows(2)
-        .filter_map(|x| (x[0] == "-L").then(|| PathBuf::from(&x[1])))
+        .filter(|&x| (x[0] == "-L"))
+        .map(|x| PathBuf::from(&x[1]))
         .inspect(|path| log::trace!("new search path: {}", path.display()))
         .collect()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -325,12 +325,14 @@ fn perform_addition(line: &str) -> u64 {
             }
             None => (segment, None),
         };
+
         // Parse number
         let (number, radix) = match number.strip_prefix("0x") {
             Some(s) => (s, 16),
             None => (number, 10),
         };
         let length = tryc!(u64::from_str_radix(number, radix));
+
         // Handle unit
         let multiplier = match unit {
             Some('K') => 1024,

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,22 +321,20 @@ fn perform_addition(line: &str) -> u64 {
         let (number, unit) = match segment.find(['K', 'M']) {
             Some(unit_pos) => {
                 let (number, unit) = segment.split_at(unit_pos);
-                (number, Some(unit))
+                (number, unit.chars().next())
             }
             None => (segment, None),
         };
-
         // Parse number
         let (number, radix) = match number.strip_prefix("0x") {
             Some(s) => (s, 16),
             None => (number, 10),
         };
         let length = tryc!(u64::from_str_radix(number, radix));
-
         // Handle unit
         let multiplier = match unit {
-            Some("K") => 1024,
-            Some("M") => 1024 * 1024,
+            Some('K') => 1024,
+            Some('M') => 1024 * 1024,
             None => 1,
             _ => unreachable!(),
         };
@@ -402,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_comment() {
+    fn ingore_comment() {
         const LINKER_SCRIPT: &str = "MEMORY
         {
             FLASH : ORIGIN = 0x00000000, LENGTH = 256K

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,6 +402,31 @@ mod tests {
     }
 
     #[test]
+    fn parse_comment() {
+        const LINKER_SCRIPT: &str = "MEMORY
+        {
+            FLASH : ORIGIN = 0x00000000, LENGTH = 256K
+            RAM : ORIGIN = 0x20000000, LENGTH = 64K /* This is a comment */
+        }
+
+        INCLUDE device.x";
+
+        assert_eq!(
+            find_ram_in_linker_script(LINKER_SCRIPT),
+            Some(MemoryEntry {
+                line: 3,
+                origin: 0x20000000,
+                length: 64 * 1024,
+            })
+        );
+
+        assert_eq!(
+            get_includes_from_linker_script(LINKER_SCRIPT),
+            vec!["device.x"]
+        );
+    }
+
+    #[test]
     fn test_perform_addition_hex_and_number() {
         const ADDITION: &str = "0x20000000 + 1000";
         let expected: u64 = 0x20000000 + 1000;


### PR DESCRIPTION
With https://github.com/knurling-rs/flip-link/commit/b7f556848a4f1c02b4f1987eb7fa5dbf95b995f6 comments in linker scripts were no longer ignored. This fixes that.

Closes https://github.com/knurling-rs/flip-link/issues/83