### PR TITLE
Setup release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,27 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Rust toolchain
+        run: rustup update stable && rustup default stable
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#88] Setup release-plz
+
+[#86]: https://github.com/knurling-rs/flip-link/pull/86
+
+## [v0.1.8] - 2024-03-06
+
 - [#86]: Release v0.1.8
 - [#85]: Setup cargo-dist
 - [#84]: Fix for comments in linker script
@@ -129,7 +135,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/knurling-rs/flip-link/compare/v0.1.7...main
+[Unreleased]: https://github.com/knurling-rs/flip-link/compare/v0.1.8...main
+[v0.1.7]: https://github.com/knurling-rs/flip-link/compare/v0.1.7...v0.1.8
 [v0.1.7]: https://github.com/knurling-rs/flip-link/compare/v0.1.6...v0.1.7
 [v0.1.6]: https://github.com/knurling-rs/flip-link/compare/v0.1.5...v0.1.g
 [v0.1.5]: https://github.com/knurling-rs/flip-link/compare/v0.1.4...v0.1.5


### PR DESCRIPTION
`release-plz` is based on `cargo-release` and maintains a Release PR, keeping it up-to-date as we merge additional commits. When we're ready to create a release, we simply merge the release PR.

It takes care of:
- CHANGELOG generation (with [git-cliff](https://git-cliff.org/)).
- Creation of GitHub releases. --> this will trigger `cargo-dist`
- Publishing to crates.io.
- Version bumps in Cargo.toml.

Read more https://github.com/MarcoIeni/release-plz.

**Todo**
- [x] configure `secrets.GITHUB_TOKEN` permissions to create PRs
- [x] create `secrets.CARGO_REGISTRY_TOKEN` (expires 07.03.2025, `publish-update` scope and only for `flip-link` crate)
    ![Screenshot from 2024-03-07 10-59-19](https://github.com/knurling-rs/flip-link/assets/37087391/ca48c890-aa11-4aa9-90c5-ef858684e1f6)

- [ ] ~~configure or disable `git-cliff`~~ --> do this after this PR, to see how the Release PR looks like