### PR TITLE
Configure release-plz

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+changelog_update = false
+dependencies_update = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#90] Configure release-plz
 - [#88] Setup release-plz
 
-[#86]: https://github.com/knurling-rs/flip-link/pull/86
+[#90]: https://github.com/knurling-rs/flip-link/pull/86
+[#88]: https://github.com/knurling-rs/flip-link/pull/86
 
 ## [v0.1.8] - 2024-03-06
 


### PR DESCRIPTION
This PR changes two configurations.

Firstly it disables the changelog update. While this feature is generally desirable, git-cliff chokes on our git history and it is not trivial to configure it properly. Therefore this is deferred.

Secondly `cargo update` will be run.