### PR TITLE
Recommend `target.'cfg(..)'.linker` for recent Cargo versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#92] Recommend `target.'cfg(..)'.linker` for recent Cargo versions
 - [#90] Configure release-plz
 - [#88] Setup release-plz
 
-[#90]: https://github.com/knurling-rs/flip-link/pull/86
+[#92]: https://github.com/knurling-rs/flip-link/pull/92
+[#90]: https://github.com/knurling-rs/flip-link/pull/90
 [#88]: https://github.com/knurling-rs/flip-link/pull/86
 
 ## [v0.1.8] - 2024-03-06

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ Change the linker from `rust-lld` (the default) to `flip-link` in `.cargo/config
 ``` toml
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 # (..)
+linker = "flip-link"
+```
+
+In versions of Cargo < 1.74, use `rustflags` to change the linker
+
+``` toml
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# (..)
 rustflags = [
   "-C", "linker=flip-link", # <- add this
   # (..)


### PR DESCRIPTION
Since Cargo [version 1.74], the linker can be selected without using `rustflags`. This way of setting it causes less conflict with other uses of `RUSTFLAGS`, which may need to be set outside `.cargo/config.toml`.

[version 1.74]: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-174-2023-11-16