### PR TITLE
Refactor tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CORE_TARGET: thumbv7m-none-eabi # needed by `core`
+  CORE_TARGET: thumbv7em-none-eabi # needed by `core`
 
 jobs:
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "assert_cmd"
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -111,9 +111,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "log"
@@ -123,15 +123,15 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "object"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "memchr",
 ]
@@ -165,27 +165,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -206,21 +206,21 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "relative-path"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+checksum = "9d5316d2a1479eeef1ea21e7f9ddc67c191d497abc8fc3ba2467857abbb68330"
 dependencies = [
  "rstest_macros",
  "rustc_version",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+checksum = "04a9df72cc1f67020b0d63ad9bfe4a323e459ea7eb68e03bd9824db49f9a4c25"
 dependencies = [
  "cfg-if",
  "glob",
@@ -254,24 +254,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "c993ed8ccba56ae856363b1845da7266a7cb78e1d146c8a32d54b45a8b831fc9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ readme = "README.md"
 env_logger = { version = "0.11", default-features = false }
 getrandom = "0.2"
 log = "0.4"
-object = { version = "0.33", default-features = false, features = ["read_core", "elf", "std"] }
+object = { version = "0.35", default-features = false, features = ["read_core", "elf", "std"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"
-rstest = { version = "0.18", default-features = false }
+rstest = { version = "0.19", default-features = false }
 
 [workspace]
 members = [".", "xtest"]

--- a/test-flip-link-app/.cargo/config.toml
+++ b/test-flip-link-app/.cargo/config.toml
@@ -1,4 +1,4 @@
-[target.thumbv7m-none-eabi]
+[target.thumbv7em-none-eabi]
 runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
 rustflags = [
   "-C", "linker=flip-link",
@@ -6,4 +6,4 @@ rustflags = [
 ]
 
 [build]
-target = "thumbv7m-none-eabi"
+target = "thumbv7em-none-eabi"

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -7,7 +7,7 @@ const CRATE: &str = "test-flip-link-app";
 /// Example firmware in `$CRATE/examples`
 const FILES: [&str; 4] = ["crash", "exception", "hello", "panic"];
 /// Compilation target firmware is build for
-const TARGET: &str = "thumbv7m-none-eabi";
+const TARGET: &str = "thumbv7em-none-eabi";
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -19,7 +19,7 @@ fn should_link_example_firmware(#[case] default_features: bool) {
     cargo::check_flip_link();
 
     // Act
-    let cmd = cargo::build_example_firmware(CRATE, default_features);
+    let cmd = cargo::build_example_firmware(default_features);
 
     // Assert
     cmd.success();
@@ -31,7 +31,7 @@ fn should_verify_memory_layout() -> Result<()> {
     cargo::check_flip_link();
 
     // Act
-    cargo::build_example_firmware(CRATE, true).success();
+    cargo::build_example_firmware(true).success();
 
     // Assert
     for elf_path in elf::paths() {
@@ -40,7 +40,7 @@ fn should_verify_memory_layout() -> Result<()> {
         let object = object::File::parse(&*elf)?;
 
         // get the relevant sections
-        let (bss, data, uninit, vector_table) = elf::get_sections(&object)?;
+        let [bss, data, uninit, vector_table] = elf::get_sections(&object);
         // compute the initial stack-pointer from `.vector_table`
         let initial_sp = elf::compute_initial_sp(&vector_table)?;
         // get the bounds of 'static RAM'
@@ -59,12 +59,14 @@ mod cargo {
 
     use assert_cmd::{assert::Assert, prelude::*};
 
+    use super::*;
+
     /// Build all examples in `$REPO/$rel_path`
     #[must_use]
-    pub fn build_example_firmware(rel_path: &str, default_features: bool) -> Assert {
+    pub(crate) fn build_example_firmware(default_features: bool) -> Assert {
         // append `rel_path` to the current working directory
         let mut firmware_dir = std::env::current_dir().unwrap();
-        firmware_dir.push(rel_path);
+        firmware_dir.push(CRATE);
 
         // disable default features or use `-v` as a no-op
         let default_features = match default_features {
@@ -80,7 +82,7 @@ mod cargo {
     }
 
     /// Check that `flip-link` is present on the system
-    pub fn check_flip_link() {
+    pub(crate) fn check_flip_link() {
         Command::new("which")
             .arg("flip-link")
             .unwrap()
@@ -100,18 +102,18 @@ mod elf {
     ///
     /// It is the first 32-bit word in the `.vector_table` section,
     /// according to the "ARMv6-M Architecture Reference Manual".
-    pub fn compute_initial_sp(vector_table: &Section) -> Result<u64> {
+    pub(crate) fn compute_initial_sp(vector_table: &Section) -> Result<u64> {
         let data = vector_table.uncompressed_data()?;
         let sp = u32::from_le_bytes(data[..4].try_into()?);
         Ok(sp as u64)
     }
 
     /// Get [`RangeInclusive`] from lowest to highest address of all sections
-    pub fn get_bounds(sections: &[Section]) -> Result<RangeInclusive<u64>> {
+    pub(crate) fn get_bounds(sections: &[Section]) -> Result<RangeInclusive<u64>> {
         // get beginning and end of all sections
         let addresses = sections
             .iter()
-            .flat_map(|sec| vec![sec.address(), sec.address() + sec.size()])
+            .flat_map(|sec| [sec.address(), sec.address() + sec.size()])
             .collect::<Vec<_>>();
 
         // get highest and lowest address of all sections
@@ -126,34 +128,23 @@ mod elf {
     /// * `.data`
     /// * `.uninit`
     /// * `.vector_table`
-    pub fn get_sections<'data, 'file>(
-        object: &'file File<'data>,
-    ) -> Result<(
-        Section<'data, 'file>,
-        Section<'data, 'file>,
-        Section<'data, 'file>,
-        Section<'data, 'file>,
-    )> {
+    pub(crate) fn get_sections<'file>(object: &'file File<'_>) -> [Section<'file, 'file>; 4] {
         // try to get section, else error
-        let get_section = |section_name| {
-            object
-                .section_by_name(section_name)
-                .ok_or(format!("error getting section `{}`", section_name))
-        };
+        let get_section = |section_name| object.section_by_name(section_name).expect(section_name);
 
-        Ok((
-            get_section(".bss")?,
-            get_section(".data")?,
-            get_section(".uninit")?,
-            get_section(".vector_table")?,
-        ))
+        [
+            get_section(".bss"),
+            get_section(".data"),
+            get_section(".uninit"),
+            get_section(".vector_table"),
+        ]
     }
 
     /// Paths to firmware binaries.
-    pub fn paths() -> Vec<PathBuf> {
+    pub(crate) fn paths() -> Vec<PathBuf> {
         FILES
-            .iter()
-            .map(|file_name| format!("{}/target/{}/debug/examples/{}", CRATE, TARGET, file_name))
+            .into_iter()
+            .map(|file_name| format!("{CRATE}/target/{TARGET}/debug/examples/{file_name}"))
             .map(PathBuf::from)
             .collect()
     }

--- a/xtest/src/main.rs
+++ b/xtest/src/main.rs
@@ -59,7 +59,7 @@ mod cargo {
 mod rustup {
     use super::*;
 
-    const TARGET: &str = "thumbv7m-none-eabi";
+    const TARGET: &str = "thumbv7em-none-eabi";
 
     pub fn install_target() -> Result<()> {
         let status = Command::new("rustup")


### PR DESCRIPTION
This PR
- switches to `thumbv7em-none-eabi` (this is to be more easily testable with Ferrocene)
- refactors `tests/verify.rs`
- updates dependencies