### PR TITLE
Add support for @file args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#96] Add support for @file args
 - [#94] Refactor tests
 - [#93] Remove TryInto import (in prelude since 2021 edition)
 - [#92] Recommend `target.'cfg(..)'.linker` for recent Cargo versions
 - [#90] Configure release-plz
 - [#88] Setup release-plz
 
+[#96]: https://github.com/knurling-rs/flip-link/pull/96
 [#94]: https://github.com/knurling-rs/flip-link/pull/94
 [#93]: https://github.com/knurling-rs/flip-link/pull/93
 [#92]: https://github.com/knurling-rs/flip-link/pull/92

--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -35,15 +35,17 @@ pub fn expand_files(args: &[String]) -> Vec<String> {
     for arg in args {
         if let Some(arg) = arg.strip_prefix('@') {
             // The normal linker was able to open the file, so this *should* never panic
-            let file = File::open(arg).expect(&format!(
-                "Unable to open {arg}, this should never happen and should be reported"
-            ));
+            let file = File::open(arg).unwrap_or_else(|e| {
+                panic!("Unable to open {arg}, this should never happen and should be reported: {e}")
+            });
             let reader = BufReader::new(file);
             for line in reader.lines() {
                 // Same as above, normal linker succeeded so we should too
-                let line = line.expect(&format!(
-                    "Invalid file {arg}, this should never happen and should be reported"
-                ));
+                let line = line.unwrap_or_else(|e| {
+                    panic!(
+                        "Invalid file {arg}, this should never happen and should be reported: {e}"
+                    )
+                });
                 // Remove quotes if they exist
                 if line.starts_with('"') && line.ends_with('"') {
                     expanded.push(line[1..line.len() - 1].to_owned());

--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -44,7 +44,6 @@ pub fn expand_files(args: &[String]) -> Vec<String> {
                 let line = line.expect(&format!(
                     "Invalid file ({arg}), this should never happen and should be reported"
                 ));
-                println!("{line}");
                 // Remove quotes if they exist
                 if line.starts_with('"') && line.ends_with('"') {
                     expanded.push(line[1..line.len() - 1].to_owned());

--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -42,7 +42,7 @@ pub fn expand_files(args: &[String]) -> Vec<String> {
             for line in reader.lines() {
                 // Same as above, normal linker succeeded so we should too
                 let line = line.expect(&format!(
-                    "Invalid file ({arg}), this should never happen and should be reported"
+                    "Invalid file {arg}, this should never happen and should be reported"
                 ));
                 // Remove quotes if they exist
                 if line.starts_with('"') && line.ends_with('"') {


### PR DESCRIPTION
Fixes #95

I couldn't reproduce the original error I encountered, so I couldn't test if this works with rustc generated files, but based on the code for my initial fix, it should work. If someone can find a way to make rustc emit the at-file args so this can be properly tested, that would be great, but I'm very confident in it as it is.