### PR TITLE
Add support for -h/--help arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#102] Add support for -h/--help arg and no arg
+
+[#102]: https://github.com/knurling-rs/flip-link/pull/102
+
 ## [v0.1.9] - 2024-08-14
 
 - [#96] Add support for @file args

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,24 @@ fn notmain() -> Result<i32> {
     // NOTE `skip` the name/path of the binary (first argument)
     let raw_args = env::args().skip(1).collect::<Vec<_>>();
 
+    // If there's no argument provided, print the help message
+    if matches!(
+        raw_args
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<&str>>()
+            .as_slice(),
+        [] | ["--help"] | ["-h"]
+    ) {
+        eprintln!(
+            "flip-link: adds zero-cost stack overflow protection to your \
+            embedded programs\nYou should not use flip-link directly from \
+            command line, use flip-link as your default linker instead. \n\n\
+            For detailed usage, check https://github.com/knurling-rs/flip-link"
+        );
+        return Ok(0);
+    }
+
     {
         let exit_status = linking::link_normally(&raw_args)?;
         if !exit_status.success() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,7 @@ fn notmain() -> Result<i32> {
     let raw_args = env::args().skip(1).collect::<Vec<_>>();
 
     // If there's no argument provided, print the help message
-    if matches!(
-        raw_args
-            .iter()
-            .map(|s| s.as_str())
-            .collect::<Vec<&str>>()
-            .as_slice(),
-        [] | ["--help"] | ["-h"]
-    ) {
+    if let None | Some("--help" | "-h") = raw_args.first().map(String::as_str) {
         eprintln!(
             "flip-link: adds zero-cost stack overflow protection to your \
             embedded programs\nYou should not use flip-link directly from \


### PR DESCRIPTION
When use `flip-link` directly from command line, now flip-link returns an error code 1:

```
$ flip-link
lld is a generic driver.
Invoke ld.lld (Unix), ld64.lld (macOS), lld-link (Windows), wasm-ld (WebAssembly) instead

flip-link: the native linker failed to link the program normally; please check your project configuration and linker scripts
```

It's inconvenient when we want to just test whether flip-link exists. In my case, I use `cargo-make` to automate the build workflow, it checks `flip-link` command's return code to determine whether to install the crate, so it will re-install flip-link everytime even though flip-link has been installed. 

This PR adds `-h`/`--help` argument. When user executes `flip-link -h` or `flip-link --help` or `flip-link` in command line, flip-link now returns:

```
$ flip-link
flip-link: adds zero-cost stack overflow protection to your embedded programs

You should not use flip-link directly from command line, use flip-link as your default linker instead. 
For detailed usage, check https://github.com/knurling-rs/flip-link
```