### PR TITLE
Add one job to mark as required for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,14 @@ jobs:
       - run: cargo clippy -- --deny warnings
       - run: cargo clippy -- --deny warnings
         working-directory: test-flip-link-app/
+
+  ci-success:
+    name: CI finished successfully
+    runs-on: ubuntu-latest
+    if: success()
+    needs:
+        - test
+        - static-checks
+    steps:
+        - name: Mark the build as successful
+          run: exit 0


### PR DESCRIPTION
Instead of marking all individual jobs as required in the branch protection rules we can mark this one job, which depends on all other jobs, as required.