### PR TITLE
Handle case where `rust-lld` is not in path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#118] Handle case where rust-lld is not in path
 - [#109] Don't cache, because it is slow
 - [#108] CI: Update cargo-dist to v0.1.27
 
+[#118]: https://github.com/knurling-rs/flip-link/pull/118
 [#109]: https://github.com/knurling-rs/flip-link/pull/109
 [#108]: https://github.com/knurling-rs/flip-link/pull/107
 

--- a/src/linking.rs
+++ b/src/linking.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Command, ExitStatus},
 };
 
-const LINKER: &str = "rust-lld";
+pub const LINKER: &str = "rust-lld";
 
 /// Normal linking with just the arguments the user provides
 pub fn link_normally(args: &[String]) -> io::Result<ExitStatus> {


### PR DESCRIPTION
When invoking flip-link in an environment where `rust-lld` is not in the path, we only get the rather unhelpful error message `Os { code: 2, kind: NotFound, message: "No such file or directory" }`.

With this PR, we report a more helpful error message that case, informing the user that whatever system linker is specified in linker.rs cannot be found.

This particular issue has been a pain point when using flip-link in an environment where we are also building rustc from source, and it took a while to realise needed to enable rust-lld when running cargo's `x.py` for flip-link to work.

Thank you!