### PR TITLE
Fix typo in `expand_files` documentation

### DIFF
--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -28,7 +28,7 @@ pub fn get_search_targets(args: &[String]) -> Vec<Cow<str>> {
         .collect()
 }
 
-/// Exapnds @file arguments into the file's contents
+/// Expands @file arguments into the file's contents
 pub fn expand_files(args: &[String]) -> Vec<String> {
     let mut expanded = Vec::with_capacity(args.len());
 


### PR DESCRIPTION
I found this while trying to figure out how to write a "test case" for homebrew. They require a non-unit-test test, but also don't have the arm target available that I could use to compile `test-flip-link-app`. If you have any ideas those would be much appreciated!