### PR TITLE
Fix some lints triggering on newer compilers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [#118] Handle case where rust-lld is not in path
 - [#109] Don't cache, because it is slow
 - [#108] CI: Update cargo-dist to v0.1.27
+- [#122] Fix some lints triggering on newer compilers
 
 [#118]: https://github.com/knurling-rs/flip-link/pull/118
 [#109]: https://github.com/knurling-rs/flip-link/pull/109

--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -15,14 +15,14 @@ pub fn get_output_path(args: &[String]) -> crate::Result<&String> {
 /// Get `search_paths`, specified by `-L`
 pub fn get_search_paths(args: &[String]) -> Vec<PathBuf> {
     args.windows(2)
-        .filter(|&x| (x[0] == "-L"))
+        .filter(|&x| x[0] == "-L")
         .map(|x| PathBuf::from(&x[1]))
         .inspect(|path| log::trace!("new search path: {}", path.display()))
         .collect()
 }
 
 /// Get `search_targets`, the names of the linker scripts, specified by `-T`
-pub fn get_search_targets(args: &[String]) -> Vec<Cow<str>> {
+pub fn get_search_targets(args: &[String]) -> Vec<Cow<'_, str>> {
     args.iter()
         .filter_map(|arg| arg.strip_prefix("-T").map(Cow::Borrowed))
         .collect()

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn in_tempdir<T>(callback: impl FnOnce(&Path) -> Result<T>) -> Result<T> {
 }
 
 /// Returns `(used_ram_length, used_ram_align)`
-fn compute_span_of_ram_sections(ram_entry: MemoryEntry, object: object::File) -> (u64, u64) {
+fn compute_span_of_ram_sections(ram_entry: MemoryEntry, object: object::File<'_>) -> (u64, u64) {
     let mut used_ram_start = u64::MAX;
     let mut used_ram_end = 0;
     let mut used_ram_align = 0;


### PR DESCRIPTION
While working on Ferrocene's in-tree [submodule of `flip-link`](https://github.com/ferrocene/ferrocene/tree/main/ferrocene/tools) I was adding a test job for it and got lints for these changes. This fixes those.