### PR TITLE
Use $CARGO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- [#138] Use $CARGO
 - [#137] Pure cargo tests
 - [#132] Remove release-plz, add note for making a release
 
+[#138]: https://github.com/knurling-rs/flip-link/pull/138
 [#137]: https://github.com/knurling-rs/flip-link/pull/137
 [#132]: https://github.com/knurling-rs/flip-link/pull/132
 

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -72,7 +72,7 @@ mod cargo {
             true => "-v",
         };
 
-        Command::new("cargo")
+        Command::new(env!("CARGO"))
             .args(["build", "--examples", default_features])
             .current_dir(firmware_dir)
             .env("PATH", path_with_flip_link())


### PR DESCRIPTION
The cargo found in `$PATH` (if any) may not be the correct cargo, e.g. in https://github.com/ferrocene/ferrocene/pull/1741.

So instead we now use the same cargo binary that builds the integration test for building the test-app.